### PR TITLE
Set header-link-color and default the settings

### DIFF
--- a/scss/_global-settings.scss
+++ b/scss/_global-settings.scss
@@ -1,17 +1,19 @@
 
 /// the theme's core brand colour
-$brand-color:           #000;
+$brand-color:           #000 !default;
 
-$button-primary-color:	#dd4814;
+$button-primary-color:	#dd4814 !default;
 
-$link-color:            #333;
+$link-color:            #333 !default;
 
-$silver:                #ccc;
+$silver:                #ccc !default;
 
-$grey:                  #ddd;
+$grey:                  #ddd !default;
 
-$error:                 #df382c;
+$error:                 #df382c !default;
 
-$pending:               #eaa818;
+$pending:               #eaa818 !default;
 
-$success:               #38b44a;
+$success:               #38b44a !default;
+
+$header-link-color:     $white !default;

--- a/scss/modules/_header.scss
+++ b/scss/modules/_header.scss
@@ -62,7 +62,6 @@
 
             @media only screen and (min-width: $navigation-threshold) {
               border-left: 0;
-              color: $white;
             }
           }
         }


### PR DESCRIPTION
# Done
- Set the header-link-color to $white
- Made the vars `!default` so they can be overridden in the site

## QA
- Run `gulp build`
- Check the header in the demo looks ok 