### PR TITLE
Add padding to cookie policy text

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -666,6 +666,14 @@
             </div>
         </div>
     </div>
+
+    <div class="cookie-policy">
+        <div class="inner-wrapper">
+            <a href="?cp=close" class="link-cta">Close</a>
+            <p>We use cookies to improve your experience. By your continued use of this site you accept such use. To change your settings please <a href="http://www.ubuntu.com/legal/terms-and-policies/privacy-policy#cookies">see our policy</a>.</p>
+        </div>
+    </div>
+
     <footer class="global clearfix no-global">
       <nav id="main-navigation" role="navigation" class="clearfix">
         <div class="legal clearfix has-cookie">

--- a/scss/modules/_cookie-policy.scss
+++ b/scss/modules/_cookie-policy.scss
@@ -20,8 +20,12 @@
       font-size: .8125em;
       margin-bottom: 0;
       margin-left: 0;
-      padding: 8px 0;
+      padding: 8px 10px;
       width: 100%;
+
+      @media only screen and (min-width: $breakpoint-medium) {
+        padding: 8px 0;
+      }
     }
 
     .link-cta {


### PR DESCRIPTION
## QA
- Run `gulp build`
- Open demo/index.html in your browser
- Check the cookie policy looks ok
- Go down to mobile view and see there is padding around the text