### PR TITLE
Update to work with npm v3 or greater/better

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A extenstion of [Vanilla framework](https://github.com/ubuntudesign/vanilla-fram
 
 ## Installing
 
-Install the Node package into your project:
+Install the Node package into your project with npm v3 or newer:
 
 ``` bash
 npm install cloud-vanilla-theme  # Installs the theme with the framework within

--- a/demo/index.html
+++ b/demo/index.html
@@ -677,7 +677,7 @@
     <footer class="global clearfix no-global">
       <nav id="main-navigation" role="navigation" class="clearfix">
         <div class="legal clearfix has-cookie">
-            <p class="twelve-col">© 2015 Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.</p>
+            <p class="twelve-col">© Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.</p>
             <ul class="inline-list clear">
                 <li><a href="/legal"><small>Legal information</small></a>
                 </li>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -42,7 +42,8 @@ gulp.task('sass', function() {
     return gulp.src('scss/**/*.scss')
         .pipe(sass({
             style: 'expanded',
-            onError: throwSassError
+            onError: throwSassError,
+            includePaths: ['node_modules/']
         }))
         .pipe(autoprefixer('last 2 version', 'safari 5', 'ie 8', 'ie 9', 'opera 12.1'))
         .pipe(gulp.dest('build/css/'))

--- a/scss/_theme.scss
+++ b/scss/_theme.scss
@@ -3,7 +3,7 @@
 @import 'global-settings';
 
 // import required files
-@import '../node_modules/vanilla-framework/scss/vanilla';
+@import 'vanilla-framework/scss/vanilla';
 
 /// cloud element styles
 @import 'modules/base';


### PR DESCRIPTION
## Done
- Remove the relative path to node_modules from the theme file
- Added node_modules as an include path when processing sass
- Remove date in demo page
- Update README to reflect the npm version requirement

## QA
- Pull down this branch
- Remove your node_modules folder
- Check which version of npm you have with `npm -v`
 - If below 2.x.x then run `npm i && gulp build` and there should be an error importing vanilla
 - If above 3.x.x then run `npm i && gulp build` and check there are no errors
- Open the demo and see if looks ok